### PR TITLE
Add GitHub Actions CI and Dependabot auto-merge workflows

### DIFF
--- a/.github/workflow-templates/auto-merge-dependabot.yml
+++ b/.github/workflow-templates/auto-merge-dependabot.yml
@@ -1,0 +1,22 @@
+name: Auto-merge Dependabot PRs
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+
+    steps:
+      - uses: dependabot/fetch-metadata@v2
+        id: metadata
+
+      - if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflow-templates/ci.yml
+++ b/.github/workflow-templates/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: ".node-version"
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm lint
+
+      - run: pnpm format:check
+
+      - run: pnpm build


### PR DESCRIPTION
## Summary
This PR adds two GitHub Actions workflow templates to automate continuous integration and dependency management processes.

## Key Changes
- **CI Workflow** (`ci.yml`): Automated testing and build pipeline that runs on pull requests and pushes to main
  - Checks out code and sets up Node.js environment using `.node-version` file
  - Installs dependencies with pnpm using frozen lockfile
  - Runs linting, format checking, and build steps
  
- **Dependabot Auto-merge Workflow** (`auto-merge-dependabot.yml`): Automatically merges non-major dependency updates
  - Triggers on all pull requests and filters for Dependabot bot
  - Fetches dependency metadata to determine update type
  - Auto-merges with squash strategy for minor and patch updates only
  - Skips major version updates to require manual review

## Implementation Details
- Both workflows are stored in `.github/workflow-templates/` for use as organization templates
- CI workflow uses minimal permissions (read-only) following security best practices
- Auto-merge workflow requires write permissions for contents and pull requests
- Dependabot auto-merge uses `gh pr merge` CLI with squash strategy for cleaner commit history

https://claude.ai/code/session_01ARDBHkczSY5io41pJ9R2oT