### PR TITLE
ci: Dependabot PRにautomergeラベルを自動付与

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -7,14 +7,21 @@ on:
 
 permissions:
   contents: write
+  issues: write
   pull-requests: write
 
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'automerge')
+    if: github.actor == 'dependabot[bot]'
 
     steps:
+      - name: Add automerge label
+        run: gh pr edit "$PR_URL" --add-label "automerge"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: dependabot/fetch-metadata@v2
         id: metadata
         with:


### PR DESCRIPTION
### Motivation
- Dependabot が作成する PR に `automerge` ラベルが付与されないケースがあり、ワークフローが期待どおりに動作しないことを防止するための対応です。
- ワークフロー側でラベル付与を補完して自動マージ運用を安定化させることを目的としています。

### Description
- `.github/workflows/auto-merge-dependabot.yml` の `permissions` に `issues: write` を追加しました。
- ジョブの実行条件をラベル有無に依存しないように `if: github.actor == 'dependabot[bot]'` に変更しました。
- Dependabot PR に対して `gh pr edit "$PR_URL" --add-label "automerge"` を実行するステップを追加し、既存の `gh pr merge --auto --squash` ステップは維持しています。

### Testing
- `nl -ba .github/workflows/auto-merge-dependabot.yml` を実行してファイル内容が期待どおりに更新されていることを確認しました。
- `git status --short` を実行して作業ツリーに変更が反映されていることを確認しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b14a319ac832b89e7c2190aab1382)