### PR TITLE
fix(actions): dependabot auto-merge を PR 作成者で判定

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
 
     steps:
       - name: Add automerge label


### PR DESCRIPTION
### Motivation
- `pull_request_target` イベントでは実行者が Dependabot 以外になることがあり、`github.actor` 判定だとジョブがスキップされるため、PR 作成者ベースで判定する必要がある。

### Description
- `.github/workflows/auto-merge-dependabot.yml` の `auto-merge` ジョブの条件を `if: github.actor == 'dependabot[bot]'` から `if: github.event.pull_request.user.login == 'dependabot[bot]'` に変更した。

### Testing
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/auto-merge-dependabot.yml'); puts 'YAML OK'"` を実行して YAML 構文チェックは成功した。
- `python - <<'PY'\nimport yaml,sys\n...\nPY` による `yaml.safe_load` チェックは `PyYAML` 未導入のため `ModuleNotFoundError` となり失敗した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ce018680c832b8aa55a02079814be)