### PR TITLE
ci: GitHub Actions を Node.js 24 対応のメジャー版へ更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: '.node-version'
           cache: 'pnpm'


### PR DESCRIPTION
### Motivation
- GitHub Actions ランナーで Node.js 20 廃止の警告が出ているため、CI で使用している JavaScript actions を Node.js 24 対応のメジャー版へ更新して将来の互換性を担保します。

### Description
- `.github/workflows/ci.yml` の `actions/checkout@v4` を `actions/checkout@v6`、`pnpm/action-setup@v4` を `pnpm/action-setup@v6`、`actions/setup-node@v4` を `actions/setup-node@v6` に置換しました。

### Testing
- 自動検証として `pnpm run format`、`pnpm run lint`、`pnpm run build` を実行し、いずれも成功しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee04036980832ba50e4aad61fd01f7)